### PR TITLE
Add ModelSelect.get_or_none()

### DIFF
--- a/peewee.py
+++ b/peewee.py
@@ -6888,6 +6888,12 @@ class BaseModelSelect(_ModelQueryHelper):
                                           'not exist:\nSQL: %s\nParams: %s' %
                                           (clone.model, sql, params))
 
+    def get_or_none(self, database=None):
+        try:
+            return self.get(database=database)
+        except self.model.DoesNotExist:
+            pass
+
     @Node.copy
     def group_by(self, *columns):
         grouping = []

--- a/tests/models.py
+++ b/tests/models.py
@@ -518,6 +518,13 @@ class TestModelAPIs(ModelTestCase):
                          'huey')
         self.assertIsNone(User.get_or_none(User.username == 'foo'))
 
+    @requires_models(User, Tweet)
+    def test_model_select_get_or_none(self):
+        huey = self.add_user('huey')
+        self.assertEqual(User.select().where(User.username == 'huey').get_or_none().username,
+                         'huey')
+        self.assertIsNone(User.select().where(User.username == 'foo').get_or_none())
+
     @requires_models(User, Color)
     def test_get_by_id(self):
         huey = self.add_user('huey')


### PR DESCRIPTION
Hello, Mr. Leifer!

First, thanks for creating and maintaining such a great library. We've been using it at Propel for many years now.

This PR adds `get_or_none()` to `ModelSelect` in an effort to make the querying API a little more consistent. `Foo.get_or_none()` is very convenient, and we'd like the same sort of convenience for things like `Foo.select().join(Bar).where(Foo.baz == baz).get_or_none()`.